### PR TITLE
Reduce whitespace in object detection preview page

### DIFF
--- a/platform/client/components/VideoPlayer.tsx
+++ b/platform/client/components/VideoPlayer.tsx
@@ -1260,14 +1260,14 @@ export default function VideoPlayer({
                 style={{
                   flex: 1,
                   overflowY: "auto",
-                  maxHeight: "65vh",
-                  minHeight: "400px",
+                  maxHeight: "55vh",
+                  minHeight: "250px",
                   display: "block",
                   paddingRight: "8px",
                   border: "1px solid #e2e8f0",
                   borderRadius: "6px",
                   padding: "12px",
-                  marginBottom: "12px",
+                  marginBottom: "4px",
                   scrollbarWidth: "thick",
                   scrollbarColor: "#5fbeeb #f1f5f9",
                   WebkitOverflowScrolling: "touch",
@@ -1457,7 +1457,7 @@ export default function VideoPlayer({
                           </div>
                           <button
                             onClick={() => {
-                              // 일괄 삭제를 위해 확인 모달을 열어서 전체 선택 삭제로 처리
+                              // 일괄 삭제를 위해 확인 ���달을 열어서 전체 선택 삭제로 처리
                               if (selectedObjectIds.length > 0) {
                                 setObjectToDelete("BULK_DELETE");
                                 setShowDeleteConfirmModal(true);

--- a/platform/client/components/VideoPlayer.tsx
+++ b/platform/client/components/VideoPlayer.tsx
@@ -552,7 +552,7 @@ export default function VideoPlayer({
     setIsEditing(false);
   };
 
-  // 뒤로가기 핸들러 - 탐지된 객체 목록으로만 이동하고 버튼 활성화 상태 유지
+  // 뒤로가기 핸들러 - ��지된 객체 목록으로만 이동하고 버튼 활성화 상태 유지
   const handleBackToObjectList = () => {
     setSelectedObjectId(null);
     setIsEditing(false);
@@ -1457,7 +1457,7 @@ export default function VideoPlayer({
                           </div>
                           <button
                             onClick={() => {
-                              // 일괄 삭제를 위해 확인 ���달을 열어서 전체 선택 삭제로 처리
+                              // 일괄 삭제를 위해 확인 모달을 열어서 전체 선택 삭제로 처리
                               if (selectedObjectIds.length > 0) {
                                 setObjectToDelete("BULK_DELETE");
                                 setShowDeleteConfirmModal(true);
@@ -1546,10 +1546,10 @@ export default function VideoPlayer({
                             background: "linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%)",
                             border: "2px solid #e2e8f0",
                             borderRadius: "12px",
-                            padding: "20px",
+                            padding: "16px",
                             boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-                            maxHeight: "60vh", // 고정 height 대신 maxHeight로 변경 (예: 60vh)
-                            minHeight: "320px", // 너무 작아지지 않게 최소값도 지정
+                            maxHeight: "50vh",
+                            minHeight: "280px",
                             overflowY: "auto",
                             overflowX: "hidden",
                             scrollbarWidth: "thin",
@@ -2093,7 +2093,7 @@ export default function VideoPlayer({
                   transition: "all 0.2s ease",
                 }}
               >
-                취소
+                취��
               </button>
               <button
                 onClick={confirmDelete}

--- a/platform/client/components/VideoPlayer.tsx
+++ b/platform/client/components/VideoPlayer.tsx
@@ -483,7 +483,7 @@ export default function VideoPlayer({
     onDownloadWebVTT();
 
     // 저장 및 다운로드 완료 메시지 표시
-    toast.success("���장 및 WebVTT 다운���드가 완료되었습니다.");
+    toast.success("���장 및 WebVTT 다운로드가 완료되었습니다.");
 
     console.log("저장 후 비디오 정보:", {
       duration: currentDuration,
@@ -649,7 +649,7 @@ export default function VideoPlayer({
       setShowDeleteConfirmModal(false);
       setObjectToDelete(null);
       setDeleteConfirmed(false);
-      // ��기��는 객체 목록을 닫은 상태로 시작
+      // ��기에는 객체 목록을 닫은 상태로 시작
       setShowObjectList(false);
 
       if (videoDuration === 0) {
@@ -987,7 +987,7 @@ export default function VideoPlayer({
               >
                 {isErasing
                   ? "🗑️ 지우개 모드 - 그려진 영역을 클릭하여 삭제하세요"
-                  : "🎨 그���기 모드 활성화 - ���우스로 드래그하여 영역을 그려보세요"}
+                  : "🎨 그���기 모드 활성화 - 마우스로 드래그하여 영역을 그려보세요"}
               </div>
             )}
           </div>
@@ -1300,7 +1300,7 @@ export default function VideoPlayer({
                     <div style={{
                       display: "flex",
                       flexDirection: "column",
-                      gap: "8px",
+                      gap: "6px",
                     }}>
                       {displayObjects.map((object) => (
                         <div
@@ -1412,7 +1412,7 @@ export default function VideoPlayer({
                               justifyContent: "center",
                               transition: "color 0.2s ease",
                             }}
-                            title="정보 보��"
+                            title="정보 보기"
                           >
                             <ChevronRight style={{ width: 16, height: 16 }} />
                           </button>
@@ -1633,7 +1633,7 @@ export default function VideoPlayer({
                                     color: "#475569",
                                   }}
                                 >
-                                  카테��리:{" "}
+                                  카테고리:{" "}
                                   {selectedObject.category ||
                                     editedCategory ||
                                     "기타"}
@@ -1902,7 +1902,7 @@ export default function VideoPlayer({
                       🔍
                     </div>
                     <div style={{ fontWeight: "500", marginBottom: "4px" }}>
-                      탐지된 객체 없음
+                      ��지된 객체 없음
                     </div>
                     <div style={{ fontSize: "0.85rem" }}>
                       "탐지된 객체" 버튼을 클릭하여
@@ -2070,7 +2070,7 @@ export default function VideoPlayer({
                   userSelect: "none",
                 }}
               >
-                상기 내용을 확인��습니다
+                상기 내용을 확인했습니다
               </label>
             </div>
 

--- a/platform/client/components/VideoPlayer.tsx
+++ b/platform/client/components/VideoPlayer.tsx
@@ -483,7 +483,7 @@ export default function VideoPlayer({
     onDownloadWebVTT();
 
     // 저장 및 다운로드 완료 메시지 표시
-    toast.success("���장 및 WebVTT 다운로드가 완료되었습니다.");
+    toast.success("���장 및 WebVTT 다운���드가 완료되었습니다.");
 
     console.log("저장 후 비디오 정보:", {
       duration: currentDuration,
@@ -552,7 +552,7 @@ export default function VideoPlayer({
     setIsEditing(false);
   };
 
-  // 뒤로가기 핸들러 - ��지된 객체 목록으로만 이동하고 버튼 활성화 상태 유지
+  // 뒤로가기 핸들러 - 탐지된 객체 목록으로만 이동하고 버튼 활성화 상태 유지
   const handleBackToObjectList = () => {
     setSelectedObjectId(null);
     setIsEditing(false);
@@ -649,7 +649,7 @@ export default function VideoPlayer({
       setShowDeleteConfirmModal(false);
       setObjectToDelete(null);
       setDeleteConfirmed(false);
-      // ��기에는 객체 목록을 닫은 상태로 시작
+      // ��기��는 객체 목록을 닫은 상태로 시작
       setShowObjectList(false);
 
       if (videoDuration === 0) {
@@ -987,7 +987,7 @@ export default function VideoPlayer({
               >
                 {isErasing
                   ? "🗑️ 지우개 모드 - 그려진 영역을 클릭하여 삭제하세요"
-                  : "🎨 그���기 모드 활성화 - 마우스로 드래그하여 영역을 그려보세요"}
+                  : "🎨 그���기 모드 활성화 - ���우스로 드래그하여 영역을 그려보세요"}
               </div>
             )}
           </div>
@@ -1046,8 +1046,8 @@ export default function VideoPlayer({
                 border: "1px solid #e5e7eb",
                 display: "flex",
                 flexDirection: "column",
-                height: "85vh",
-                maxHeight: "900px",
+                height: "75vh",
+                maxHeight: "750px",
                 animation: "slideInRight 0.3s ease-out",
                 transform: "translateX(0)",
                 overflowY: "auto",
@@ -1412,7 +1412,7 @@ export default function VideoPlayer({
                               justifyContent: "center",
                               transition: "color 0.2s ease",
                             }}
-                            title="정보 보기"
+                            title="정보 보��"
                           >
                             <ChevronRight style={{ width: 16, height: 16 }} />
                           </button>
@@ -1633,7 +1633,7 @@ export default function VideoPlayer({
                                     color: "#475569",
                                   }}
                                 >
-                                  카테고리:{" "}
+                                  카테��리:{" "}
                                   {selectedObject.category ||
                                     editedCategory ||
                                     "기타"}
@@ -2070,7 +2070,7 @@ export default function VideoPlayer({
                   userSelect: "none",
                 }}
               >
-                상기 내용을 확인했습니다
+                상기 내용을 확인��습니다
               </label>
             </div>
 
@@ -2093,7 +2093,7 @@ export default function VideoPlayer({
                   transition: "all 0.2s ease",
                 }}
               >
-                취��
+                취소
               </button>
               <button
                 onClick={confirmDelete}

--- a/platform/client/components/VideoPlayer.tsx
+++ b/platform/client/components/VideoPlayer.tsx
@@ -779,7 +779,7 @@ export default function VideoPlayer({
           </button>
         </div>
 
-        {/* 메인 컨텐츠 영역 */}
+        {/* ���인 컨텐츠 영역 */}
         <div
           style={{
             display: "flex",
@@ -1376,7 +1376,7 @@ export default function VideoPlayer({
                             </div>
                             <div
                               style={{ fontSize: "0.8rem", color: "#6b7280" }}
-                            // 신뢰도 삭제
+                            // 신뢰�� 삭제
                             >
                             </div>
                           </div>
@@ -1559,7 +1559,7 @@ export default function VideoPlayer({
                           }}
                         >
                           {/* 이름 섹션 */}
-                          <div style={{ marginBottom: "20px" }}>
+                          <div style={{ marginBottom: "16px" }}>
                             <div
                               style={{
                                 fontSize: "0.9rem",
@@ -1643,7 +1643,7 @@ export default function VideoPlayer({
                           </div>
 
                           {/* 코드 섹션 */}
-                          <div style={{ marginBottom: "20px" }}>
+                          <div style={{ marginBottom: "16px" }}>
                             <div
                               style={{
                                 fontSize: "0.9rem",
@@ -1688,7 +1688,7 @@ export default function VideoPlayer({
                           </div>
 
                           {/* DL.reservoir domain 섹션 */}
-                          <div style={{ marginBottom: "20px" }}>
+                          <div style={{ marginBottom: "16px" }}>
                             <div
                               style={{
                                 fontSize: "0.9rem",
@@ -1763,7 +1763,7 @@ export default function VideoPlayer({
                           </div>
 
                           {/* 추가정보 섹션 */}
-                          <div style={{ marginBottom: "20px" }}>
+                          <div style={{ marginBottom: "16px" }}>
                             <div
                               style={{
                                 fontSize: "0.9rem",
@@ -1821,7 +1821,7 @@ export default function VideoPlayer({
                           </div>
 
                           {/* 수정 버튼 - 객체 정보 하단으로 이동 */}
-                          <div style={{ marginBottom: "20px", display: "flex", flexDirection: "column", gap: "8px" }}>
+                          <div style={{ marginBottom: "12px", display: "flex", flexDirection: "column", gap: "8px" }}>
                             <button
                               onClick={() => {
                                 if (isEditing) {
@@ -1902,7 +1902,7 @@ export default function VideoPlayer({
                       🔍
                     </div>
                     <div style={{ fontWeight: "500", marginBottom: "4px" }}>
-                      ��지된 객체 없음
+                      탐지된 객체 없음
                     </div>
                     <div style={{ fontSize: "0.85rem" }}>
                       "탐지된 객체" 버튼을 클릭하여


### PR DESCRIPTION
## Purpose
The user requested to reduce excessive whitespace in the object detection preview page. When navigating to the detected objects modification page and clicking on the detected objects button, the objects list displayed too much whitespace at the bottom, making the interface less efficient.

## Code changes
- **Container height adjustments**: Reduced main container height from `85vh` to `75vh` and maxHeight from `900px` to `750px`
- **Object list area optimization**: Decreased maxHeight from `65vh` to `55vh` and minHeight from `400px` to `250px`
- **Spacing reductions**: 
  - Reduced marginBottom from `12px` to `4px` for the object list container
  - Decreased gap between objects from `8px` to `6px`
  - Reduced padding from `20px` to `16px` in object detail sections
  - Minimized section margins from `20px` to `16px` throughout the component
- **Detail modal adjustments**: Reduced maxHeight from `60vh` to `50vh` and minHeight from `320px` to `280px`

These changes create a more compact and efficient layout while maintaining readability and usability of the object detection interface.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f33ddbc67bd348e1bf9c93575f39f11d/pulse-zone)

👀 [Preview Link](https://f33ddbc67bd348e1bf9c93575f39f11d-pulse-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f33ddbc67bd348e1bf9c93575f39f11d</projectId>-->
<!--<branchName>pulse-zone</branchName>-->